### PR TITLE
Add option for synchronous evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Hemm: Holistic Evaluation of Multi-modal Generative Models
 
-Hemm is a library for performing comprehensive benchmark of text-to-image diffusion models on image quality and prompt comprehension integrated with [Weights & Biases](https://wandb.ai/site) and [Weave](https://wandb.github.io/weave/). Hemm is inspired by [Holistic Evaluation of Text-To-Image Models](https://crfm.stanford.edu/helm/heim/v1.0.0/).
+Hemm is a library for performing comprehensive benchmark of text-to-image diffusion models on image quality and prompt comprehension integrated with [Weights & Biases](https://wandb.ai/site) and [Weave](https://wandb.github.io/weave/).
+
+Hemm is highly inspired by the following projects:
+- [Holistic Evaluation of Text-To-Image Models](https://crfm.stanford.edu/helm/heim/v1.0.0/)
+- [T2I-CompBench: A Comprehensive Benchmark for Open-world Compositional Text-to-image Generation](https://karine-h.github.io/T2I-CompBench/)
+- [T2I-CompBench++: An Enhanced and Comprehensive Benchmark for Compositional Text-to-image Generation](https://karine-h.github.io/T2I-CompBench-new/)
+- [GenEval: An Object-Focused Framework for Evaluating Text-to-Image Alignment](https://arxiv.org/abs/2310.11513)
 
 > [!WARNING]  
 > Hemm is still in early development, the API is subject to change, expect things to break. If you are interested in contributing, please feel free to open an issue and/or raise a pull request.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,12 @@
 # Hemm: Holistic Evaluation of Multi-modal Generative Models
 
-Hemm is a library for performing comprehensive benchmark of text-to-image diffusion models on image quality and prompt comprehension integrated with [Weights & Biases](https://wandb.ai/site) and [Weave](https://wandb.github.io/weave/). Hemm is inspired by [Holistic Evaluation of Text-To-Image Models](https://crfm.stanford.edu/helm/heim/v1.0.0/).
+Hemm is a library for performing comprehensive benchmark of text-to-image diffusion models on image quality and prompt comprehension integrated with [Weights & Biases](https://wandb.ai/site) and [Weave](https://wandb.github.io/weave/). 
+
+Hemm is highly inspired by the following projects:
+- [Holistic Evaluation of Text-To-Image Models](https://crfm.stanford.edu/helm/heim/v1.0.0/)
+- [T2I-CompBench: A Comprehensive Benchmark for Open-world Compositional Text-to-image Generation](https://karine-h.github.io/T2I-CompBench/)
+- [T2I-CompBench++: An Enhanced and Comprehensive Benchmark for Compositional Text-to-image Generation](https://karine-h.github.io/T2I-CompBench-new/)
+- [GenEval: An Object-Focused Framework for Evaluating Text-to-Image Alignment](https://arxiv.org/abs/2310.11513)
 
 !!! warning
     Hemm is still in early development, the API is subject to change, expect things to break. If you are interested in contributing, please feel free to open an issue and/or raise a pull request.

--- a/examples/2d_spatial_eval/evaluate_spatial_relationship.py
+++ b/examples/2d_spatial_eval/evaluate_spatial_relationship.py
@@ -3,9 +3,9 @@ from typing import Optional, Tuple
 
 import fire
 import jsonlines
-import wandb
 import weave
 
+import wandb
 from hemm.eval_pipelines import BaseDiffusionModel, EvaluationPipeline
 from hemm.metrics.spatial_relationship import SpatialRelationshipMetric2D
 from hemm.metrics.spatial_relationship.judges import DETRSpatialRelationShipJudge

--- a/examples/evaluate_weave_image_quality.py
+++ b/examples/evaluate_weave_image_quality.py
@@ -1,7 +1,7 @@
 import fire
-import wandb
 import weave
 
+import wandb
 from hemm.eval_pipelines import BaseDiffusionModel, EvaluationPipeline
 from hemm.metrics.image_quality import LPIPSMetric, PSNRMetric, SSIMMetric
 

--- a/examples/evaluate_weave_prompt_alignment.py
+++ b/examples/evaluate_weave_prompt_alignment.py
@@ -1,9 +1,9 @@
 import fire
-import wandb
 import weave
 
+import wandb
 from hemm.eval_pipelines import BaseDiffusionModel, EvaluationPipeline
-from hemm.metrics.prompt_alignment import CLIPScoreMetric, CLIPImageQualityScoreMetric
+from hemm.metrics.prompt_alignment import CLIPImageQualityScoreMetric, CLIPScoreMetric
 
 
 def main(

--- a/hemm/eval_pipelines/eval_pipeline.py
+++ b/hemm/eval_pipelines/eval_pipeline.py
@@ -8,7 +8,7 @@ import wandb
 
 from ..metrics.base import BaseMetric
 from ..utils import base64_decode_image
-from .hemm_evaluation import AsyncHemmEvaluation, SyncHemmEvaluation
+from .hemm_evaluation import AsyncHemmEvaluation, HemmEvaluation
 from .model import BaseDiffusionModel
 
 
@@ -127,7 +127,7 @@ class EvaluationPipeline(ABC):
             with weave.attributes(self.evaluation_configs):
                 asyncio.run(evaluation.evaluate(self.infer_async))
         else:
-            evaluation = SyncHemmEvaluation(
+            evaluation = HemmEvaluation(
                 dataset=dataset,
                 scorers=[metric_fn.evaluate for metric_fn in self.metric_functions],
             )

--- a/hemm/eval_pipelines/eval_pipeline.py
+++ b/hemm/eval_pipelines/eval_pipeline.py
@@ -1,10 +1,11 @@
 from abc import ABC
+import asyncio
 from typing import Dict, List, Union
 
 import wandb
 import weave
 
-from .hemm_evaluation import SyncHemmEvaluation
+from .hemm_evaluation import AsyncHemmEvaluation, SyncHemmEvaluation
 from .model import BaseDiffusionModel
 from ..metrics.base import BaseMetric
 from ..utils import base64_decode_image
@@ -78,6 +79,19 @@ class EvaluationPipeline(ABC):
         )
         return output
 
+    @weave.op()
+    async def infer_async(self, prompt: str) -> Dict[str, str]:
+        """Async inference function to generate images for the given prompt.
+
+        Args:
+            prompt (str): Prompt to generate the image.
+
+        Returns:
+            Dict[str, str]: Dictionary containing base64 encoded image to be logged as
+                a Weave object.
+        """
+        return self.infer(prompt)
+
     def log_summary(self):
         """Log the evaluation summary to the Weights & Biases dashboard."""
         config = wandb.config
@@ -91,18 +105,31 @@ class EvaluationPipeline(ABC):
             {f"Evalution/{self.model.diffusion_model_name_or_path}": self.wandb_table}
         )
 
-    def __call__(self, dataset: Union[List[Dict], str]) -> None:
+    def __call__(
+        self, dataset: Union[List[Dict], str], async_evaluation: bool = False
+    ) -> None:
         """Evaluate the Stable Diffusion model on the given dataset.
 
         Args:
             dataset (Union[List[Dict], str]): Dataset to evaluate the model on. If a string is
                 passed, it is assumed to be a Weave dataset reference.
+            async_evaluation (bool): Flag to enable asynchronous evaluation.
         """
         dataset = weave.ref(dataset).get() if isinstance(dataset, str) else dataset
-        evaluation = SyncHemmEvaluation(
-            dataset=dataset,
-            scorers=[metric_fn.evaluate for metric_fn in self.metric_functions],
-        )
-        with weave.attributes(self.evaluation_configs):
-            evaluation.evaluate(self.infer)
+        if async_evaluation:
+            evaluation = AsyncHemmEvaluation(
+                dataset=dataset,
+                scorers=[
+                    metric_fn.evaluate_async for metric_fn in self.metric_functions
+                ],
+            )
+            with weave.attributes(self.evaluation_configs):
+                asyncio.run(evaluation.evaluate(self.infer_async))
+        else:
+            evaluation = SyncHemmEvaluation(
+                dataset=dataset,
+                scorers=[metric_fn.evaluate for metric_fn in self.metric_functions],
+            )
+            with weave.attributes(self.evaluation_configs):
+                evaluation.evaluate(self.infer)
         self.log_summary()

--- a/hemm/eval_pipelines/eval_pipeline.py
+++ b/hemm/eval_pipelines/eval_pipeline.py
@@ -1,14 +1,15 @@
-from abc import ABC
 import asyncio
+from abc import ABC
 from typing import Dict, List, Union
 
-import wandb
 import weave
 
-from .hemm_evaluation import AsyncHemmEvaluation, SyncHemmEvaluation
-from .model import BaseDiffusionModel
+import wandb
+
 from ..metrics.base import BaseMetric
 from ..utils import base64_decode_image
+from .hemm_evaluation import AsyncHemmEvaluation, SyncHemmEvaluation
+from .model import BaseDiffusionModel
 
 
 class EvaluationPipeline(ABC):

--- a/hemm/eval_pipelines/hemm_evaluation.py
+++ b/hemm/eval_pipelines/hemm_evaluation.py
@@ -1,16 +1,21 @@
+import inspect
+import textwrap
+import time
 import traceback
-from typing import Callable, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
+import numpy as np
 import rich
 import wandb
 import weave
+from tqdm.auto import tqdm
 from weave.flow.dataset import Dataset
-from weave.flow.model import Model
+from weave.flow.model import Model, get_infer_method
+from weave.flow.scorer import Scorer, auto_summarize, get_scorer_attributes
 from weave.flow.util import async_foreach
-from weave.flow.scorer import Scorer, get_scorer_attributes
 from weave.trace.errors import OpCallError
 from weave.trace.env import get_weave_parallelism
-from weave.trace.op import Op
+from weave.trace.op import Op, BoundOp
 
 
 def replace_backslash_dot(d):
@@ -26,7 +31,7 @@ def replace_backslash_dot(d):
         return d
 
 
-class HemmEvaluation(weave.Evaluation):
+class AsyncHemmEvaluation(weave.Evaluation):
     dataset: Union[Dataset, list]
     scorers: Optional[list[Union[Callable, Op, Scorer]]] = None
     preprocess_model_input: Optional[Callable] = None
@@ -67,6 +72,209 @@ class HemmEvaluation(weave.Evaluation):
             eval_rows.append(eval_row)
 
         summary = await self.summarize(eval_rows)
+        wandb.log(replace_backslash_dot(summary))
+        rich.print("Evaluation summary", summary)
+        return summary
+
+
+class SyncHemmEvaluation(weave.Evaluation):
+    dataset: Union[Dataset, List[Dict]]
+    scorers: Optional[list[Union[Callable, Op, Scorer]]] = None
+    preprocess_model_input: Optional[Callable] = None
+    trials: int = 1
+
+    @weave.op()
+    def predict_and_score(
+        self, model: Union[Callable, Model], example: dict
+    ) -> Dict[str, Any]:
+        if self.preprocess_model_input == None:
+            model_input = example
+        else:
+            model_input = self.preprocess_model_input(example)  # type: ignore
+
+        if callable(model):
+            model_predict = model
+        else:
+            model_predict = get_infer_method(model)
+
+        model_predict_fn_name = (
+            model_predict.name
+            if isinstance(model_predict, Op)
+            else model_predict.__name__
+        )
+
+        if isinstance(model_predict, Op):
+            predict_signature = model_predict.signature
+        else:
+            predict_signature = inspect.signature(model_predict)
+        model_predict_arg_names = list(predict_signature.parameters.keys())
+        # If the op is a `BoundOp`, then the first arg is automatically added at
+        # call time and we should exclude it from the args required from the
+        # user.
+        if isinstance(model_predict, BoundOp):
+            model_predict_arg_names = model_predict_arg_names[1:]
+
+        if isinstance(model_input, dict):
+            model_predict_args = {
+                k: v for k, v in model_input.items() if k in model_predict_arg_names
+            }
+        else:
+            if len(model_predict_arg_names) == 1:
+                model_predict_args = {model_predict_arg_names[0]: model_input}
+            else:
+                raise ValueError(
+                    f"{model_predict} expects arguments: {model_predict_arg_names}, provide a preprocess_model_input function that returns a dict with those keys."
+                )
+        try:
+            model_start_time = time.time()
+            model_output = model_predict(**model_predict_args)
+        except OpCallError as e:
+            dataset_column_names = list(example.keys())
+            dataset_column_names_str = ", ".join(dataset_column_names[:3])
+            if len(dataset_column_names) > 3:
+                dataset_column_names_str += ", ..."
+            required_arg_names = [
+                param.name
+                for param in predict_signature.parameters.values()
+                if param.default == inspect.Parameter.empty
+            ]
+            if isinstance(model_predict, BoundOp):
+                required_arg_names = required_arg_names[1:]
+
+            message = textwrap.dedent(
+                f"""
+                Call error: {e}
+
+                Options for resolving:
+                a. change {model_predict_fn_name} argument names to match a subset of dataset column names: {dataset_column_names_str}
+                b. change dataset column names to match expected {model_predict_fn_name} argument names: {required_arg_names}
+                c. construct Evaluation with a preprocess_model_input function that accepts a dataset example and returns a dict with keys expected by {model_predict_fn_name}
+                """
+            )
+            raise OpCallError(message)
+        except Exception as e:
+            rich.print("model_output failed")
+            traceback.print_exc()
+            model_output = None
+        model_latency = time.time() - model_start_time
+
+        scores = {}
+        scorers = cast(list[Union[Op, Scorer]], self.scorers or [])
+        for scorer in scorers:
+            scorer_name, score_fn, _ = get_scorer_attributes(scorer)
+            if isinstance(score_fn, Op):
+                score_signature = score_fn.signature
+            else:
+                score_signature = inspect.signature(score_fn)
+            score_arg_names = list(score_signature.parameters.keys())
+
+            # If the op is a `BoundOp`, then the first arg is automatically added at
+            # call time and we should exclude it from the args required from the
+            # user.
+            if isinstance(score_arg_names, BoundOp):
+                score_arg_names = score_arg_names[1:]
+
+            if "model_output" not in score_arg_names:
+                raise OpCallError(
+                    f"Scorer {scorer_name} must have a 'model_output' argument, to receive the output of the model function."
+                )
+
+            if isinstance(example, dict):
+                score_args = {k: v for k, v in example.items() if k in score_arg_names}
+            else:
+                if len(score_arg_names) == 2:
+                    score_args = {score_arg_names[0]: example}
+                else:
+                    raise ValueError(
+                        f"{score_fn} expects arguments: {score_arg_names}, provide a preprocess_model_input function that returns a dict with those keys."
+                    )
+            score_args["model_output"] = model_output
+
+            try:
+                result = score_fn(**score_args)
+            except OpCallError as e:
+                dataset_column_names = list(example.keys())
+                dataset_column_names_str = ", ".join(dataset_column_names[:3])
+                if len(dataset_column_names) > 3:
+                    dataset_column_names_str += ", ..."
+                required_arg_names = [
+                    param.name
+                    for param in score_signature.parameters.values()
+                    if param.default == inspect.Parameter.empty
+                ]
+                if isinstance(score_fn, BoundOp):
+                    required_arg_names = required_arg_names[1:]
+                required_arg_names.remove("model_output")
+
+                message = textwrap.dedent(
+                    f"""
+                    Call error: {e}
+
+                    Options for resolving:
+                    a. change {scorer_name} argument names to match a subset of dataset column names ({dataset_column_names_str})
+                    b. change dataset column names to match expected {scorer_name} argument names: {required_arg_names}
+                    """
+                )
+                raise OpCallError(message)
+            scores[scorer_name] = result
+
+        return {
+            "model_output": model_output,
+            "scores": scores,
+            "model_latency": model_latency,
+        }
+
+    @weave.op()
+    def summarize(self, eval_table: Union[weave.WeaveList, list]) -> dict:
+        summary = {}
+        if not isinstance(eval_table, weave.WeaveList):
+            eval_table = weave.WeaveList(eval_table)
+        model_output_summary = auto_summarize(eval_table.column("model_output"))
+        if model_output_summary:
+            summary["model_output"] = model_output_summary
+        scorers = self.scorers or []
+        for scorer in scorers:
+            scorer_name, _, summarize_fn = get_scorer_attributes(scorer)
+            scorer_scores = eval_table.column("scores").column(scorer_name)
+            summary[scorer_name] = summarize_fn(scorer_scores)  # type: ignore
+        summary["model_latency"] = {
+            "mean": float(np.mean(eval_table.column("model_latency"))),
+        }
+        return summary
+
+    @weave.op()
+    def evaluate(self, model: Union[Callable, Model]) -> dict:
+        eval_rows = []
+        n_complete = 0
+        dataset = cast(Dataset, self.dataset)
+        _rows = dataset.rows
+        trial_rows = list(_rows) * self.trials
+
+        def eval_example(example: Dict[str, Any]) -> Dict[str, Any]:
+            try:
+                eval_row = self.predict_and_score(model, example)
+            except OpCallError as e:
+                raise e
+            except Exception as e:
+                rich.print("Predict and score failed")
+                traceback.print_exc()
+                return {"model_output": None, "scores": {}}
+            return eval_row
+
+        for example in tqdm(trial_rows, desc="Evaluating", leave=False):
+            eval_row = eval_example(example)
+            n_complete += 1
+            if eval_row == None:
+                eval_row = {"model_output": None, "scores": {}}
+            if eval_row["scores"] == None:
+                eval_row["scores"] = {}
+            for scorer in self.scorers or []:
+                scorer_name, _, _ = get_scorer_attributes(scorer)
+                if scorer_name not in eval_row["scores"]:
+                    eval_row["scores"][scorer_name] = {}
+            eval_rows.append(eval_row)
+
+        summary = self.summarize(eval_rows)
         wandb.log(replace_backslash_dot(summary))
         rich.print("Evaluation summary", summary)
         return summary

--- a/hemm/eval_pipelines/hemm_evaluation.py
+++ b/hemm/eval_pipelines/hemm_evaluation.py
@@ -78,7 +78,7 @@ class AsyncHemmEvaluation(weave.Evaluation):
         return summary
 
 
-class SyncHemmEvaluation(weave.Evaluation):
+class HemmEvaluation(weave.Evaluation):
     dataset: Union[Dataset, List[Dict]]
     scorers: Optional[list[Union[Callable, Op, Scorer]]] = None
     preprocess_model_input: Optional[Callable] = None

--- a/hemm/eval_pipelines/hemm_evaluation.py
+++ b/hemm/eval_pipelines/hemm_evaluation.py
@@ -6,16 +6,17 @@ from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import numpy as np
 import rich
-import wandb
 import weave
 from tqdm.auto import tqdm
 from weave.flow.dataset import Dataset
 from weave.flow.model import Model, get_infer_method
 from weave.flow.scorer import Scorer, auto_summarize, get_scorer_attributes
 from weave.flow.util import async_foreach
-from weave.trace.errors import OpCallError
 from weave.trace.env import get_weave_parallelism
-from weave.trace.op import Op, BoundOp
+from weave.trace.errors import OpCallError
+from weave.trace.op import BoundOp, Op
+
+import wandb
 
 
 def replace_backslash_dot(d):

--- a/hemm/eval_pipelines/model.py
+++ b/hemm/eval_pipelines/model.py
@@ -1,4 +1,3 @@
-from ast import Tuple
 from typing import Dict
 
 import torch
@@ -16,19 +15,25 @@ class BaseDiffusionModel(weave.Model):
         enable_cpu_offfload (bool): Enable CPU offload for the diffusion model.
         image_height (int): The height of the generated image.
         image_width (int): The width of the generated image.
+        disable_safety_checker (bool): Disable safety checker for the diffusion model.
     """
 
     diffusion_model_name_or_path: str
     enable_cpu_offfload: bool = False
     image_height: int = 512
     image_width: int = 512
+    disable_safety_checker: bool = True
     _torch_dtype: torch.dtype = torch.float16
     _pipeline: DiffusionPipeline = None
 
-    def initialize(self):
-        self._pipeline = DiffusionPipeline.from_pretrained(
-            self.diffusion_model_name_or_path, torch_dtype=self._torch_dtype
-        )
+    def initialize(self) -> None:
+        pipeline_init_kwargs = {
+            "pretrained_model_name_or_path": self.diffusion_model_name_or_path,
+            "torch_dtype": self._torch_dtype,
+        }
+        if self.disable_safety_checker:
+            pipeline_init_kwargs["safety_checker"] = None
+        self._pipeline = DiffusionPipeline.from_pretrained(**pipeline_init_kwargs)
         if self.enable_cpu_offfload:
             self._pipeline.enable_model_cpu_offload()
         else:
@@ -37,11 +42,14 @@ class BaseDiffusionModel(weave.Model):
 
     @weave.op()
     def predict(self, prompt: str, seed: int) -> Dict[str, str]:
-        image = self._pipeline(
+        pipeline_output = self._pipeline(
             prompt,
             num_images_per_prompt=1,
             height=self.image_height,
             width=self.image_width,
             generator=torch.Generator(device="cuda").manual_seed(seed),
-        ).images[0]
-        return {"image": base64_encode_image(image)}
+        )
+        return {
+            "image": base64_encode_image(pipeline_output.images[0]),
+            "nsfw_content_detected": pipeline_output.nsfw_content_detected is not None,
+        }

--- a/hemm/metrics/base.py
+++ b/hemm/metrics/base.py
@@ -10,3 +10,7 @@ class BaseMetric(ABC):
     @abstractmethod
     def evaluate(self) -> Dict[str, Any]:
         pass
+
+    @abstractmethod
+    def evaluate_async(self) -> Dict[str, Any]:
+        pass

--- a/hemm/metrics/image_quality/lpips.py
+++ b/hemm/metrics/image_quality/lpips.py
@@ -70,8 +70,15 @@ class LPIPSMetric(BaseImageQualityMetric):
         )
 
     @weave.op()
-    def __call__(
+    def evaluate(
         self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
     ) -> Union[float, Dict[str, float]]:
         _ = "LPIPSMetric"
-        return super().__call__(prompt, ground_truth_image, model_output)
+        return super().evaluate(prompt, ground_truth_image, model_output)
+
+    @weave.op()
+    async def evaluate_async(
+        self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
+    ) -> Union[float, Dict[str, float]]:
+        _ = "LPIPSMetric"
+        return self.evaluate(prompt, ground_truth_image, model_output)

--- a/hemm/metrics/image_quality/lpips.py
+++ b/hemm/metrics/image_quality/lpips.py
@@ -70,7 +70,7 @@ class LPIPSMetric(BaseImageQualityMetric):
         )
 
     @weave.op()
-    async def __call__(
+    def __call__(
         self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
     ) -> Union[float, Dict[str, float]]:
         _ = "LPIPSMetric"

--- a/hemm/metrics/image_quality/psnr.py
+++ b/hemm/metrics/image_quality/psnr.py
@@ -64,8 +64,15 @@ class PSNRMetric(BaseImageQualityMetric):
         )
 
     @weave.op()
-    def __call__(
+    def evaluate(
         self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
     ) -> Union[float, Dict[str, float]]:
         _ = "PSNRMetric"
-        return super().__call__(prompt, ground_truth_image, model_output)
+        return super().evaluate(prompt, ground_truth_image, model_output)
+
+    @weave.op()
+    async def evaluate_async(
+        self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
+    ) -> Union[float, Dict[str, float]]:
+        _ = "PSNRMetric"
+        return self.evaluate(prompt, ground_truth_image, model_output)

--- a/hemm/metrics/image_quality/psnr.py
+++ b/hemm/metrics/image_quality/psnr.py
@@ -64,7 +64,7 @@ class PSNRMetric(BaseImageQualityMetric):
         )
 
     @weave.op()
-    async def __call__(
+    def __call__(
         self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
     ) -> Union[float, Dict[str, float]]:
         _ = "PSNRMetric"

--- a/hemm/metrics/image_quality/ssim.py
+++ b/hemm/metrics/image_quality/ssim.py
@@ -91,8 +91,15 @@ class SSIMMetric(BaseImageQualityMetric):
         )
 
     @weave.op()
-    def __call__(
+    def evaluate(
         self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
     ) -> Union[float, Dict[str, float]]:
         _ = "SSIMMetric"
-        return super().__call__(prompt, ground_truth_image, model_output)
+        return super().evaluate(prompt, ground_truth_image, model_output)
+
+    @weave.op()
+    async def evaluate_async(
+        self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
+    ) -> Union[float, Dict[str, float]]:
+        _ = "SSIMMetric"
+        return self.evaluate(prompt, ground_truth_image, model_output)

--- a/hemm/metrics/image_quality/ssim.py
+++ b/hemm/metrics/image_quality/ssim.py
@@ -91,7 +91,7 @@ class SSIMMetric(BaseImageQualityMetric):
         )
 
     @weave.op()
-    async def __call__(
+    def __call__(
         self, prompt: str, ground_truth_image: str, model_output: Dict[str, Any]
     ) -> Union[float, Dict[str, float]]:
         _ = "SSIMMetric"

--- a/hemm/metrics/prompt_alignment/blip_score.py
+++ b/hemm/metrics/prompt_alignment/blip_score.py
@@ -48,6 +48,13 @@ class BLIPScoreMertric(BasePromptAlignmentMetric):
         )
 
     @weave.op()
-    def __call__(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
+    def evaluate(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
         _ = "BLIPScoreMertric"
-        return super().__call__(prompt, model_output)
+        return super().evaluate(prompt, model_output)
+
+    @weave.op()
+    async def evaluate_async(
+        self, prompt: str, model_output: Dict[str, Any]
+    ) -> Dict[str, float]:
+        _ = "BLIPScoreMertric"
+        return self.evaluate(prompt, model_output)

--- a/hemm/metrics/prompt_alignment/blip_score.py
+++ b/hemm/metrics/prompt_alignment/blip_score.py
@@ -48,8 +48,6 @@ class BLIPScoreMertric(BasePromptAlignmentMetric):
         )
 
     @weave.op()
-    async def __call__(
-        self, prompt: str, model_output: Dict[str, Any]
-    ) -> Dict[str, float]:
+    def __call__(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
         _ = "BLIPScoreMertric"
         return super().__call__(prompt, model_output)

--- a/hemm/metrics/prompt_alignment/clip_iqa_score.py
+++ b/hemm/metrics/prompt_alignment/clip_iqa_score.py
@@ -80,8 +80,6 @@ class CLIPImageQualityScoreMetric(BasePromptAlignmentMetric):
         return score_dict
 
     @weave.op()
-    async def __call__(
-        self, prompt: str, model_output: Dict[str, Any]
-    ) -> Dict[str, float]:
+    def __call__(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
         _ = "CLIPImageQualityScoreMetric"
         return super().__call__(prompt, model_output)

--- a/hemm/metrics/prompt_alignment/clip_iqa_score.py
+++ b/hemm/metrics/prompt_alignment/clip_iqa_score.py
@@ -80,6 +80,13 @@ class CLIPImageQualityScoreMetric(BasePromptAlignmentMetric):
         return score_dict
 
     @weave.op()
-    def __call__(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
+    def evaluate(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
         _ = "CLIPImageQualityScoreMetric"
-        return super().__call__(prompt, model_output)
+        return super().evaluate(prompt, model_output)
+
+    @weave.op()
+    async def evaluate_async(
+        self, prompt: str, model_output: Dict[str, Any]
+    ) -> Dict[str, float]:
+        _ = "CLIPImageQualityScoreMetric"
+        return self.evaluate(prompt, model_output)

--- a/hemm/metrics/prompt_alignment/clip_score.py
+++ b/hemm/metrics/prompt_alignment/clip_score.py
@@ -45,8 +45,6 @@ class CLIPScoreMetric(BasePromptAlignmentMetric):
         )
 
     @weave.op()
-    async def __call__(
-        self, prompt: str, model_output: Dict[str, Any]
-    ) -> Dict[str, float]:
+    def __call__(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
         _ = "CLIPScoreMetric"
         return super().__call__(prompt, model_output)

--- a/hemm/metrics/prompt_alignment/clip_score.py
+++ b/hemm/metrics/prompt_alignment/clip_score.py
@@ -45,6 +45,13 @@ class CLIPScoreMetric(BasePromptAlignmentMetric):
         )
 
     @weave.op()
-    def __call__(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
+    def evaluate(self, prompt: str, model_output: Dict[str, Any]) -> Dict[str, float]:
         _ = "CLIPScoreMetric"
-        return super().__call__(prompt, model_output)
+        return super().evaluate(prompt, model_output)
+
+    @weave.op()
+    async def evaluate_async(
+        self, prompt: str, model_output: Dict[str, Any]
+    ) -> Dict[str, float]:
+        _ = "CLIPScoreMetric"
+        return self.evaluate(prompt, model_output)

--- a/hemm/metrics/spatial_relationship/judges/detr.py
+++ b/hemm/metrics/spatial_relationship/judges/detr.py
@@ -3,13 +3,12 @@ from io import BytesIO
 from typing import List
 
 import torch
-from PIL import Image
-from transformers import DetrImageProcessor, DetrForObjectDetection
-
 import weave
+from PIL import Image
+from transformers import DetrForObjectDetection, DetrImageProcessor
 
-from .commons import BoundingBox, CartesianCoordinate2D
 from ....utils import base64_decode_image
+from .commons import BoundingBox, CartesianCoordinate2D
 
 
 class DETRSpatialRelationShipJudge(weave.Model):

--- a/hemm/metrics/spatial_relationship/spatial_relationship_2d.py
+++ b/hemm/metrics/spatial_relationship/spatial_relationship_2d.py
@@ -1,15 +1,15 @@
 from typing import Any, Dict, List, Optional, Union
 
-import wandb
 import weave
 from PIL import Image
 
+import wandb
+
+from ...utils import base64_decode_image, base64_encode_image
+from ..base import BaseMetric
 from .judges import DETRSpatialRelationShipJudge
 from .judges.commons import BoundingBox
 from .utils import annotate_with_bounding_box, get_iou
-from ...utils import base64_decode_image, base64_encode_image
-
-from ..base import BaseMetric
 
 
 class SpatialRelationshipMetric2D(BaseMetric):

--- a/hemm/metrics/spatial_relationship/spatial_relationship_2d.py
+++ b/hemm/metrics/spatial_relationship/spatial_relationship_2d.py
@@ -215,7 +215,7 @@ class SpatialRelationshipMetric2D(BaseMetric):
         }
 
     @weave.op()
-    async def evaluate(
+    def evaluate(
         self,
         prompt: str,
         entity_1: str,

--- a/hemm/metrics/spatial_relationship/spatial_relationship_2d.py
+++ b/hemm/metrics/spatial_relationship/spatial_relationship_2d.py
@@ -243,3 +243,14 @@ class SpatialRelationshipMetric2D(BaseMetric):
             prompt, image, entity_1, entity_2, relationship, boxes
         )
         return {self.name: judgement["score"]}
+
+    @weave.op()
+    async def evaluate_async(
+        self,
+        prompt: str,
+        entity_1: str,
+        entity_2: str,
+        relationship: str,
+        model_output: Dict[str, Any],
+    ) -> Dict[str, Union[bool, float, int]]:
+        return self.evaluate(prompt, entity_1, entity_2, relationship, model_output)

--- a/hemm/metrics/spatial_relationship/utils.py
+++ b/hemm/metrics/spatial_relationship/utils.py
@@ -4,8 +4,8 @@ import cv2
 import numpy as np
 from PIL import Image
 
-from .judges.commons import BoundingBox
 from ...utils import base64_decode_image
+from .judges.commons import BoundingBox
 
 
 def get_iou(entity_1: BoundingBox, entity_2: BoundingBox) -> float:

--- a/hemm/utils.py
+++ b/hemm/utils.py
@@ -1,17 +1,17 @@
 import base64
 import io
 import os
-from PIL import Image
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
 import jsonlines
-import wandb
 import weave
 from datasets import load_dataset
+from PIL import Image
 from tqdm.auto import tqdm
 from weave.trace.refs import ObjectRef
 
+import wandb
 
 EXT_TO_MIMETYPE = {
     ".jpg": "image/jpeg",


### PR DESCRIPTION
This PR makes the following changes:

- [x] Split up the legacy `HemmEvaluation` class into 2 classes: `AsyncHemmEvaluation` and `HemmEvaluation` for async and sequential execution respectively.
- [x] Add `async` method `evaluate_async` to the metrics.
- [x] Add `async` method `infer_async` to `EvaluationPipeline`.
- [x] Add option to disable safety checker in `BaseDiffusionModel`.
- [x] Update readme to cite more sources of inspiration.